### PR TITLE
Bug: Fix handling of /NAMES collection 

### DIFF
--- a/twitch/client.py
+++ b/twitch/client.py
@@ -44,6 +44,11 @@ class Client:
                 alias = f' (with the alias ' \
                         f'{coro.__name__})' if event_name else ''
 
+                if real_name.startswith('_'):
+                    raise ValueError(
+                        f'event names cannot start with an underscore, '
+                        f'those are reserverd for the library: {real_name}')
+
                 client.event_handler.register(real_name, coro)
                 log.debug(
                     f'{real_name}{alias} '

--- a/twitch/events.py
+++ b/twitch/events.py
@@ -14,7 +14,6 @@ TAG_REQUEST_ACKED = 'tag_request_acked'
 ----------------------------
 CONNECTED = 'connected'
 DISCONNECT = 'disconnect'
-AUTHENTICATED = 'authenticated'
 
 # raw socket events
 ----------------------------
@@ -26,7 +25,7 @@ SOCKET_RECEIVE = 'socket_receive'
 MESSAGE = 'message'
 USER_JOIN_CHANNEL = 'user_join_channel'
 USER_LEFT_CHANNEL = 'user_leave_channel'
-LIST_CHATTERS = 'list_chatters'
+LIST_USERS = 'list_users'
 MOD_STATUS_CHANGED = 'mod_status_updated'
 CHAT_CLEARED = 'chat_cleared'
 MESSAGE_CLEARED = 'message_cleared'
@@ -41,12 +40,17 @@ USER_STATE_CHANGED = 'user_updated'
 # will notify listeners about any undocumented and/or
 # error messages from twitch
 UNKNOWN = 'unknown'
+
+# reserved events
+----------------------------
+AUTHENTICATED = '_authenticated'
+
 """
 
 EventDef = namedtuple('EventDef', 'PINGED PONGED CONNECTED '
-                                  'DISCONNECT AUTHENTICATED SOCKET_SEND '
+                                  'DISCONNECT SOCKET_SEND '
                                   'SOCKET_RECEIVE MESSAGE USER_JOIN_CHANNEL '
-                                  'USER_LEFT_CHANNEL LIST_CHATTERS '
+                                  'USER_LEFT_CHANNEL LIST_USERS '
                                   'MOD_STATUS_CHANGED CHAT_CLEARED '
                                   'MESSAGE_CLEARED '
                                   'HOST_MODE_CHANGED CHANNELS_REJOINED '
@@ -54,19 +58,19 @@ EventDef = namedtuple('EventDef', 'PINGED PONGED CONNECTED '
                                   'USER_STATE_CHANGED UNKNOWN '
                                   'TAG_REQUEST_ACKED MEMBERSHIP_REQUEST_ACKED '
                                   'COMMANDS_REQUEST_ACKED '
-                                  'CHAT_ROOMS_REQUEST_ACKED')
+                                  'CHAT_ROOMS_REQUEST_ACKED '
+                                  'AUTHENTICATED')
 
 Event = EventDef(PINGED='ping',
                  PONGED='pong',
                  CONNECTED='connected',
                  DISCONNECT='disconnect',
-                 AUTHENTICATED='authenticated',
                  SOCKET_SEND='socket_send',
                  SOCKET_RECEIVE='socket_receive',
                  MESSAGE='message',
                  USER_JOIN_CHANNEL='user_join_channel',
                  USER_LEFT_CHANNEL='user_leave_channel',
-                 LIST_CHATTERS='list_chatters',
+                 LIST_USERS='list_users',
                  MOD_STATUS_CHANGED='mod_status_updated',
                  CHAT_CLEARED='chat_cleared',
                  MESSAGE_CLEARED='message_cleared',
@@ -79,4 +83,5 @@ Event = EventDef(PINGED='ping',
                  MEMBERSHIP_REQUEST_ACKED='membership_request_acked',
                  COMMANDS_REQUEST_ACKED='commands_request_acked',
                  CHAT_ROOMS_REQUEST_ACKED='chat_rooms_request_acked',
-                 UNKNOWN='unknown')
+                 UNKNOWN='unknown',
+                 AUTHENTICATED='_authenticated')

--- a/twitch/opcodes.py
+++ b/twitch/opcodes.py
@@ -40,7 +40,7 @@ USERSTATE = 'USERSTATE'
 
 OpCodeDef = namedtuple('OpCodeDef',
                        'PING PONG NICK PASS PRIVMSG '
-                       'JOIN PART MODE NAMES CLEARCHAT '
+                       'JOIN PART MODE CLEARCHAT '
                        'CLEARMSG HOSTTARGET NOTICE RECONNECT '
                        'ROOMSTATE USERNOTICE USERSTATE CAP ACK REQ')
 
@@ -52,7 +52,6 @@ OpCode = OpCodeDef(PING='PING',
                    JOIN='JOIN',
                    PART='PART',
                    MODE='MODE',
-                   NAMES='NAMES',
                    CLEARCHAT='CLEARCHAT',
                    CLEARMSG='CLEARMSG',
                    HOSTTARGET='HOSTTARGET',

--- a/twitch/websocket.py
+++ b/twitch/websocket.py
@@ -146,8 +146,9 @@ class TwitchWebSocket(websockets.client.WebSocketClientProtocol):
     async def incoming_message(self, msg):
         self._emit(Event.SOCKET_RECEIVE, msg)
 
-        new_line = CRLF if CRLF in msg else LF
-        msg_parts = split_skip_empty_parts(msg, new_line)
+        # IRC spec (https://tools.ietf.org/html/rfc2812)
+        # says new lines will always be CRLF
+        msg_parts = split_skip_empty_parts(msg, CRLF)
         msg_parts = self._handle_glhf(msg_parts)
         if msg_parts:
             if len(msg_parts) == 1:


### PR DESCRIPTION
Old parsing algorithm wasn't very dynamic in how the server can send us messages. Now we should be robust enough to capture every message correctly. 
**Assumption**: If there is no documented opcode in the message, it must be part of a /NAMES collection. This is explicitly stated in the documentation, but it was an observation I made. So I'll be using that until I hit a case where this assumption is wrong.