### PR TITLE
Feature: Commands Plugin: Add helper to auto join channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,7 @@ The commands plugin makes it possible to get a ping-pong bot running **under 10 
 ```python
 from twitch.plugins.commands import Bot
 
-bot = Bot(command_prefix='>')
-
-@bot.event()
-async def on_connected(user):
-    await bot.join_channel('channel_name')
+bot = Bot(command_prefix='>', channels=['channel_name'])
 
 
 @bot.command()
@@ -82,13 +78,10 @@ the command will still get invoked.
 ```python
 from twitch.plugins.commands import Bot, FuzzyMatch, FuzzyRatio
 
-bot = Bot(command_prefix='?')
+bot = Bot(command_prefix='?', channels=['channel_name'])
 
 fuzzy = FuzzyMatch(ratio=FuzzyRatio.SIMPLE, threshold=85)
 
-@bot.event()
-async def on_connected(user):
-    await bot.join_channel('channel_name')
 
 @bot.command(fuzzy_match=fuzzy)
 async def headcount(ctx, val: int):

--- a/twitch/event_handler.py
+++ b/twitch/event_handler.py
@@ -50,18 +50,16 @@ class EventHandler:
                 f'must be a coroutine function to be registered')
 
         event = f'on_{event}' if not event.startswith('on_') else event
-        if event == f'on_{Event.MESSAGE}':
-            def get_name(coro):
-                return coro.func.__name__ if isinstance(coro, partial) else \
-                    coro.__name__
 
-            coros = getattr(self, event, [])
-            # ensure the same on_message coro can't be registered twice
-            if coro_name not in [get_name(c) for c in coros]:
-                coros.append(coro)
-            setattr(self, event, coros)
-        else:
-            setattr(self, event, coro)
+        def get_name(coro):
+            return coro.func.__name__ if isinstance(coro, partial) else \
+                coro.__name__
+
+        coros = getattr(self, event, [])
+        # ensure the same on_message coro can't be registered twice
+        if coro_name not in [get_name(c) for c in coros]:
+            coros.append(coro)
+        setattr(self, event, coros)
 
     def emit(self, event, *args, **kwargs):
         handler = self._handlers.get(event)
@@ -102,12 +100,8 @@ class EventHandler:
                     del listeners[idx]
 
         try:
-            if method == f'on_{Event.MESSAGE}':
-                on_message_coros = getattr(self, method)
-                self._schedule_event(on_message_coros, method, *args, **kwargs)
-            else:
-                coro = getattr(self, method)
-                self._schedule_event([coro], method, *args, **kwargs)
+            coros = getattr(self, method)
+            self._schedule_event(coros, method, *args, **kwargs)
         except AttributeError:
             pass
 

--- a/twitch/websocket.py
+++ b/twitch/websocket.py
@@ -101,7 +101,10 @@ class WebSocketClient(websockets.client.WebSocketClientProtocol):
         self._emit(Event.PONGED)
 
     async def send_join(self, channel_name):
-        msg = f'{OpCode.JOIN} {CHANNEL_PREFIX}{channel_name}'
+        channel_name = channel_name if channel_name.startswith(
+            CHANNEL_PREFIX) else CHANNEL_PREFIX + channel_name
+        channel_name = channel_name.lower()
+        msg = f'{OpCode.JOIN} {channel_name}'
         await self.send(msg)
 
     async def send_message(self, channel_name, message):


### PR DESCRIPTION
Sometimes people may not care about printing a `'hey we connected message'`, and therefore dont want to have to listen for  `Event.CONNECTED` to manually join to the channels.

Adding a kwarg `channels` that allows users to pass in a list of channels they want to join so it does it for them.

Also opened up the event_handler to allow multiple handlers to be registered for every event (aslong as they are different handlers). There really is no reason to restrict this, and it allows users to still provide a `Event.CONNECTED` handlers if they still want that `'hey we connected message'` in their console.

Fixed a bug with joining channels. The channel name HAS to be lowercased and start with the prefix `#`. I was handling the latter case, but not the former. Now calling `Client.join_channel()` is case-insensitive.